### PR TITLE
Differential saves with full ExclusionTree support

### DIFF
--- a/include/Logging.h
+++ b/include/Logging.h
@@ -106,7 +106,7 @@ public:
 	}
 
 	/// <summary>
-	/// Formats microseconds into a proper time string
+	/// Formats nanoseconds into a proper time string
 	/// </summary>
 	/// <returns></returns>
 	static std::string FormatTimeNS(int64_t nanoseconds)

--- a/include/Types.h
+++ b/include/Types.h
@@ -691,7 +691,11 @@ public:
 // --------------------------------------------------------------
 namespace Types
 {
+#if defined(_WIN32) || defined(_WIN64) || defined(__CYGWIN__)
 	class __declspec(novtable) control_block
+#elif defined(unix) || defined(__unix__) || defined(__unix)
+	class control_block
+#endif
 	{
 	public:
 		//std::atomic<long> _ref_count = 1;

--- a/src/ExclusionTree.cpp
+++ b/src/ExclusionTree.cpp
@@ -92,6 +92,7 @@ bool ExclusionTreeNode::WriteData(std::ostream* buffer, size_t& offset, size_t l
 			if (_children[i]) {
 				CHECK(abuf.Write<FormID>(_children[i]->GetFormID()));
 			} else {
+				logcritical("Exclusion Tree Node is missing");
 				CHECK(abuf.Write<FormID>(0));
 			}
 		}

--- a/src/LZMAStreambuf.cpp
+++ b/src/LZMAStreambuf.cpp
@@ -189,8 +189,10 @@ int LZMAStreambuf::underflow()
 			_in->read(&_compressedBuffer[0], _bufferSize);
 
 			// check for possible I/O error
-			if (_in->bad())
-				throw std::runtime_error("LZMAStreamBuf: Error while reading the provided input stream!");
+			if (_in->bad()) {
+				return EOF;
+				//throw std::runtime_error("LZMAStreamBuf: Error while reading the provided input stream!");
+			}
 
 			_lzmaStream.next_in =
 				reinterpret_cast<unsigned char*>(_compressedBuffer.get());


### PR DESCRIPTION
Divides the ExclusionTree into its nodes that can now be saved individually, allowing differential saves to only save nodes that are new or have been modified.